### PR TITLE
fix: pubspec warning

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -107,10 +107,12 @@ flutter_intl:
 flutter:
   generate: true
   uses-material-design: true
-  assets:
-    - assets/
-    - assets/images/
-    - assets/icons/
+
+  # In order for you to include assets to the app we recommend you to use the paths below, uncomment them and set the files inside them based on what they are (Images or Icons)
+  # assets:
+  #   - assets/
+  #   - assets/images/
+  #   - assets/icons/
 
   fonts:
     - family: Roboto Black


### PR DESCRIPTION
**Associated tickets**:
- TBD

**Description**:
This PR removes the warning about not been able to find the `assets/` folders.

**Before**:
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/57040392/217517243-c560eb0e-dfae-4d09-8f26-92e1f1da1abc.png">


**Now**:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/57040392/217517085-3beea28d-6ee2-46c0-981f-9e4078f712c2.png">

