### PR TITLE
Remove connectivity plus package 

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   intl_utils: ^2.8.2
   cupertino_icons: ^1.0.5
   dio: ^5.1.2
-  connectivity_plus: ^4.0.0
   async: ^2.11.0
   flutter_bloc: ^8.1.2
   get_it: ^7.6.0

--- a/modules/common/pubspec.yaml
+++ b/modules/common/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   intl: ^0.18.0
   intl_utils: ^2.8.2
   cupertino_icons: ^1.0.5
-  connectivity_plus: ^4.0.0
   async: ^2.11.0
   flutter_bloc: ^8.1.2
   get_it: ^7.6.0

--- a/modules/data/lib/repositories/product_repository_impl.dart
+++ b/modules/data/lib/repositories/product_repository_impl.dart
@@ -1,4 +1,3 @@
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:common/core/failure/failure.dart';
 import 'package:common/core/result_type.dart';
 import 'package:data/data_sources/remote/abstract/product_data_source.dart';
@@ -12,10 +11,6 @@ class ProductRepositoryImpl implements ProductRepository {
 
   @override
   Future<ResultType<List<Product>, Failure>> getProducts() async {
-    final connectivityResult = await (Connectivity().checkConnectivity());
-    if (connectivityResult == ConnectivityResult.none) {
-      return TError(ConnectionFailure());
-    }
     final productResult = await _productDataSource.getProducts();
     return productResult.mapSuccess(
       (products) => products.map((e) => Product.fromEntity(e)).toList(),

--- a/modules/data/pubspec.yaml
+++ b/modules/data/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.1.1
   dio: ^5.1.2
-  connectivity_plus: ^4.0.0
   async: ^2.11.0
   flutter_bloc: ^8.1.2
   get_it: ^7.6.0

--- a/modules/domain/pubspec.yaml
+++ b/modules/domain/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus: ^4.0.0
   async: ^2.11.0
   flutter_bloc: ^8.1.2
   get_it: ^7.6.0


### PR DESCRIPTION
### Description
Removed connectivity plus package, it was causing a crash in iOS.

Fixed by @amaury901130 in ATM https://github.com/rootstrap/tax-app-atm/pull/189 

